### PR TITLE
Fix error in get-stats-cron.sh

### DIFF
--- a/sources/templates/outbound-proxy-CF.yaml
+++ b/sources/templates/outbound-proxy-CF.yaml
@@ -452,7 +452,7 @@ Resources:
                   #
                   ###
                   region=`curl --silent http://169.254.169.254/latest/dynamic/instance-identity/document | grep region | cut -f 4 -d '"'`
-                  instanceId=`curl --silent  curl http://169.254.169.254/latest/meta-data/instance-id`
+                  instanceId=`curl --silent http://169.254.169.254/latest/meta-data/instance-id`
                   
                   squidclient -h localhost cache_object://localhost/ mgr:5min | grep "client_http.request\|client_http.hits\|client_http.errors\|client_http.kbytes_in\|client_http.kbytes_out\|server.all." | while read line ; do
                       name=`echo $line | cut -d "=" -f 1`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The curl command was typed twice which caused the script to error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
