### PR TITLE
Parameter ProxyPort is used in the target group, so the target squid …

### DIFF
--- a/sources/templates/outbound-proxy-CF.yaml
+++ b/sources/templates/outbound-proxy-CF.yaml
@@ -530,8 +530,8 @@ Resources:
                  # And finally deny all other access to this proxy
                  http_access deny all
 
-                 # Squid normally listens to port 3128
-                 http_port 3128 ssl-bump cert=/etc/squid/cert.pem
+                 # Squid normally listens to port 3128, but needs to be parametrized here
+                 http_port ${ProxyPort} ssl-bump cert=/etc/squid/cert.pem
                  acl allowed_https_sites ssl::server_name "/etc/squid/squid.allowed.sites.txt"
                  acl step1 at_step SslBump1
                  acl step2 at_step SslBump2


### PR DESCRIPTION
…must listen on the same port

*Issue #, if available:*

*Description of changes:* The `ProxyPort` parameter is not honoured in the squid configuration, making the setup fail when set to anything than 3128.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
