### PR TITLE
fix: binds squid to ipv4 interfaces

### DIFF
--- a/sources/templates/outbound-proxy-CF.yaml
+++ b/sources/templates/outbound-proxy-CF.yaml
@@ -531,7 +531,7 @@ Resources:
                  http_access deny all
 
                  # Squid normally listens to port 3128, but needs to be parametrized here
-                 http_port ${ProxyPort} ssl-bump cert=/etc/squid/cert.pem
+                 http_port 0.0.0.0:${ProxyPort} ssl-bump cert=/etc/squid/cert.pem
                  acl allowed_https_sites ssl::server_name "/etc/squid/squid.allowed.sites.txt"
                  acl step1 at_step SslBump1
                  acl step2 at_step SslBump2


### PR DESCRIPTION
*Description of changes:*

After deploying the example, I noticed that the NLB was not registering the targets as healthy. Debugging via SSH showed no processes listening on port 3128 over IPv4. It seems that this behaviour is related to a downstream update in squid itself, which now requires this to be enabled explicitly by specifying an IPv4 interface as part of the `http_port` statement.

After making this configuration change, everything worked as expected.