### PR TITLE
Improved security

### DIFF
--- a/sources/templates/outbound-proxy-CF.yaml
+++ b/sources/templates/outbound-proxy-CF.yaml
@@ -483,6 +483,10 @@ Resources:
                  acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
                  acl localnet src 127.0.0.1
 
+                 # The Instance Metadata Service
+                 # (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instance-metadata-limiting-access)
+                 acl imds dst 169.254.169.254
+
 
                  acl SSL_ports port 443
                  acl Safe_ports port 80		# http
@@ -500,6 +504,9 @@ Resources:
                  #
                  # Recommended minimum Access Permission configuration:
                  #
+                 # Deny requests to the Instance Metadata Service
+                 http_access deny imds
+
                  # Deny requests to certain unsafe ports
                  http_access deny !Safe_ports
 

--- a/sources/templates/outbound-proxy-CF.yaml
+++ b/sources/templates/outbound-proxy-CF.yaml
@@ -517,10 +517,8 @@ Resources:
                  http_access allow localhost manager
                  http_access deny manager
 
-                 # We strongly recommend the following be uncommented to protect innocent
-                 # web applications running on the proxy server who think the only
-                 # one who can access services on "localhost" is a local user
-                 #http_access deny to_localhost
+                 # Deny requests to services running on localhost
+                 http_access deny to_localhost
 
                  #
                  # INSERT YOUR OWN RULE(S) HERE TO ALLOW ACCESS FROM YOUR CLIENTS


### PR DESCRIPTION
*Description of changes:*

I'd like to improve the security provided by the Squid configuration, to make it harder for customers to accidentally expose sensitive information or services they did not intend to expose via the Squid proxy, by explicitly denying requests to the [Instance Metadata Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html#instance-metadata-limiting-access) as well as to services running on localhost.

**To be absolutely clear, with the current configuration neither of these are exposed.** I just want to be extra careful, and also bring these points to the attention of any customer who might be about to deploy their own proxying infrastructure.